### PR TITLE
yum install obdiag no need excute "source /usr/local/oceanbase-diagnostic-tool/init.sh"

### DIFF
--- a/rpm/oceanbase-diagnostic-tool.spec
+++ b/rpm/oceanbase-diagnostic-tool.spec
@@ -80,5 +80,6 @@ find /usr/local/oceanbase-diagnostic-tool/obdiag -type f -exec chmod 644 {} \;
 ln -sf /usr/local/oceanbase-diagnostic-tool/obdiag /usr/bin/obdiag
 chmod +x /usr/local/oceanbase-diagnostic-tool/obdiag
 cp -rf /usr/local/oceanbase-diagnostic-tool/init_obdiag_cmd.sh /etc/profile.d/obdiag.sh
+sh /usr/local/oceanbase-diagnostic-tool/init.sh
 echo -e 'Please execute the following command to init obdiag:\n'
-echo -e '\033[32m source /usr/local/oceanbase-diagnostic-tool/init.sh \n \033[0m'
+echo -e '\033[32m source ~/.bashrc \n \033[0m'


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
<!-- Please clearly and concisely describe your solution. -->

close #177 
